### PR TITLE
fix: only process function if runtime is NodeJS

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -78,7 +78,7 @@
         ],
         "guard-for-in": "off",
         "id-blacklist": [
-            "error",
+            "off",
             "any",
             "Number",
             "number",

--- a/src/serverlessTypes.ts
+++ b/src/serverlessTypes.ts
@@ -1,3 +1,5 @@
+export type ServerlessTSFunctionMap = Record<string, ServerlessTSFunction>
+
 export interface ServerlessTSInstance {
   cli: {
     log(str: string): void
@@ -12,15 +14,14 @@ export interface ServerlessTSInstance {
 export interface ServerlessTSService {
   provider: {
     name: string
+    runtime?: string
   }
   custom: {
     typeScript: {
       tsconfigFilePath: string | undefined
     }
   }
-  functions: {
-    [key: string]: ServerlessTSFunction
-  }
+  functions: ServerlessTSFunctionMap
   package: ServerlessTSPackage
   getAllFunctions(): string[]
 }
@@ -34,6 +35,7 @@ export interface ServerlessTSOptions {
 export interface ServerlessTSFunction {
   handler: string
   package: ServerlessTSPackage
+  runtime?: string
 }
 
 export interface ServerlessTSPackage {

--- a/tests/index.functions.test.ts
+++ b/tests/index.functions.test.ts
@@ -1,0 +1,111 @@
+import TypeScriptPlugin from '../src'
+import { ServerlessTSInstance, ServerlessTSFunctionMap } from '../src/serverlessTypes'
+
+const createInstance = (functions: ServerlessTSFunctionMap, globalRuntime?: string): ServerlessTSInstance => ({
+  cli: {
+    log: jest.fn()
+  },
+  config: {
+    servicePath: 'servicePath'
+  },
+  service: {
+    provider: {
+      name: 'aws',
+      runtime: globalRuntime
+    },
+    package: {
+      individually: true,
+      include: [],
+      exclude: []
+    },
+    functions,
+    getAllFunctions: jest.fn()
+  },
+  pluginManager: {
+      spawn: jest.fn()
+  }
+})
+
+describe('functions', () => {
+  const functions: ServerlessTSFunctionMap = {
+    hello: {
+        handler: 'tests/assets/hello.handler',
+        package: {
+            include: [],
+            exclude: []
+        }
+    },
+    world: {
+        handler: 'tests/assets/world.handler',
+        runtime: 'nodejs12.x',
+        package: {
+            include: [],
+            exclude: []
+        },
+    },
+    js: {
+        handler: 'tests/assets/jsfile.create',
+        package: {
+            include: [],
+            exclude: []
+        }
+    },
+    notActuallyTypescript: {
+        handler: 'tests/assets/jsfile.create',
+        package: {
+            include: [],
+            exclude: []
+        },
+        runtime: 'go1.x'
+    },
+  }
+
+  describe('when the provider runtime is Node', () => {
+    it('can get filter out non node based functions', () => {
+        const slsInstance = createInstance(functions, 'nodejs10.x')
+        const plugin = new TypeScriptPlugin(slsInstance, {})
+
+        expect(
+          Object.values(plugin.functions).map(fn => fn.handler),
+        ).toEqual(
+            [
+                'tests/assets/hello.handler',
+                'tests/assets/world.handler',
+                'tests/assets/jsfile.create',
+            ],
+        )
+    })
+  })
+
+  describe('when the provider runtime is not Node', () => {
+      it('can get filter out non node based functions', () => {
+        const slsInstance = createInstance(functions, 'python2.7')
+        const plugin = new TypeScriptPlugin(slsInstance, {})
+
+        expect(
+          Object.values(plugin.functions).map(fn => fn.handler),
+        ).toEqual(
+            [
+                'tests/assets/world.handler',
+            ],
+        )
+      })
+  })
+
+  describe('when the provider runtime is undefined', () => {
+    it('can get filter out non node based functions', () => {
+        const slsInstance = createInstance(functions)
+        const plugin = new TypeScriptPlugin(slsInstance, {})
+
+        expect(
+          Object.values(plugin.functions).map(fn => fn.handler),
+        ).toEqual(
+            [
+                'tests/assets/hello.handler',
+                'tests/assets/world.handler',
+                'tests/assets/jsfile.create',
+            ],
+        )
+    })
+  })
+})

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,7 +4,8 @@
     "target": "es6",
     "declaration": true,
     "sourceMap": true,
-    "outDir": "dist"
+    "outDir": "dist",
+    "esModuleInterop": true
   },
   "include": ["src/**/*.ts"],
   "exclude": [

--- a/yarn.lock
+++ b/yarn.lock
@@ -3456,9 +3456,9 @@ type-check@~0.3.2:
     prelude-ls "~1.1.2"
 
 typescript@^3.4.1:
-  version "3.4.1"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.4.1.tgz#b6691be11a881ffa9a05765a205cb7383f3b63c6"
-  integrity sha512-3NSMb2VzDQm8oBTLH6Nj55VVtUEpe/rgkIzMir0qVoLyjDZlnMBva0U6vDiV3IH+sl/Yu6oP5QwsAQtHPmDd2Q==
+  version "3.7.5"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.7.5.tgz#0692e21f65fd4108b9330238aac11dd2e177a1ae"
+  integrity sha512-/P5lkRXkWHNAbcJIiHPfRoKqyd7bsyCma1hZNUGfn20qm64T6ZBlrzprymeu918H+mB/0rIg2gGK/BXkhhYgBw==
 
 uglify-js@^3.1.4:
   version "3.5.2"


### PR DESCRIPTION
This bugfix comes from two contributors which made two PRs at source repo: [196](https://github.com/prisma-labs/serverless-plugin-typescript/pull/196) and [197](https://github.com/prisma-labs/serverless-plugin-typescript/pull/197).

The former merged the changes from the later, making it easier to merge those PRs on this fork.