### PR TITLE
feat: add option to compile typescript files that are not referenced

### DIFF
--- a/__tests__/utils.test.ts
+++ b/__tests__/utils.test.ts
@@ -5,9 +5,9 @@ import {
 	getTypescriptConfig,
 	makeDefaultTypescriptConfig,
 } from '../src/utils';
-import { ServerlessTSFunction } from '../src/types';
+import { ServerlessTSFunctionMap } from '../src/types';
 
-const functions: { [key: string]: ServerlessTSFunction } = {
+const functions: ServerlessTSFunctionMap = {
 	hello: {
 		handler: '__tests__/__fixtures__/hello.handler',
 		package: {

--- a/src/types.ts
+++ b/src/types.ts
@@ -20,6 +20,12 @@ export interface ServerlessTSService {
 		runtime?: string;
 	};
 	custom?: {
+		/**
+		 * Custom options to be passed to this plugin.
+		 * - tsconfigFilePath: Custom tsconfig file to be used instead of
+		 *   default.
+		 * - include/exclude: Specify external typescript files (not referenced
+		 *   by lambda functions) to be included at the final bundle. */
 		typeScript?: {
 			tsconfigFilePath?: string;
 			include?: string[];

--- a/src/types.ts
+++ b/src/types.ts
@@ -22,6 +22,8 @@ export interface ServerlessTSService {
 	custom?: {
 		typeScript?: {
 			tsconfigFilePath?: string;
+			include?: string[];
+			exclude?: string[];
 		};
 	};
 	functions: ServerlessTSFunctionMap;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -12,6 +12,7 @@ import {
 import * as fse from 'fs-extra';
 import _ from 'lodash';
 import * as path from 'path';
+import globby from 'globby';
 
 import { ServerlessTSFunction } from './types';
 
@@ -188,4 +189,12 @@ export const getTypescriptConfig = (
 	}
 
 	return makeDefaultTypescriptConfig();
+};
+
+export const getFiles = (include?: string[], exclude?: string[]): string[] => {
+	if (!include || !exclude) {
+		return [];
+	}
+
+	return globby.sync([...include, ...exclude.map((e) => `!${e}`)]);
 };


### PR DESCRIPTION
Hi!

I'm using the [Ts.ED Framework](https://tsed.io/ ) which resolves it's controller, services, etc. automatically so that they are not necessarily referenced from a .ts file (see https://tsed.io/docs/configuration.html#load-configuration-from-file).
When using this plugin this resulted in missing files in the package because this plugin only compiles the lambda function handler (which is the best choice for most projects).

To solve my issue I added an include and exclude option to the custom variables and adjusted the `compileTs` method so that all files from include are compiled when this option is set.